### PR TITLE
feat: support rollbar's captureEvent

### DIFF
--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -56,5 +56,9 @@ export default Service.extend({
 
   debug(...args) {
     return this.get('notifier').debug(...args);
+  },
+
+  captureEvent(...args) {
+    return this.get('notifier').captureEvent(...args);
   }
 });


### PR DESCRIPTION
Adds support for rollbar's `captureEvent` [method](https://docs.rollbar.com/docs/rollbarjs-telemetry).